### PR TITLE
Added public endpoint JWT filter bypass check

### DIFF
--- a/backend/src/main/java/com/qwarty/auth/filter/JwtAuthFilter.java
+++ b/backend/src/main/java/com/qwarty/auth/filter/JwtAuthFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             @NonNull HttpServletResponse response,
             @NonNull FilterChain filterChain)
             throws IOException, ServletException {
-        
+
         final String authHeader = request.getHeader("Authorization");
 
         if (authHeader == null || !authHeader.startsWith("Bearer ") || skipJwtFilter(request.getRequestURI())) {


### PR DESCRIPTION
Simple PR, encountered an issue where the JWT Auth filter fails on auth endpoints (which are intended to be public endppoints) **if sent with a request that has an expired JWT access token**. This ends up firing CORS policy errors on the frontend.

This fixes the issue by letting the security filter chain handle the request, skipping the rest of `JwtAuthFilter`'s check.